### PR TITLE
this should fix id$ generation,

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,11 @@ seneca.use('mem-store',{ map:{ '-/-/foo':'*' }});
 
 seneca.use('seneca-elasticsearch', {
   refreshOnSave : true,                 // highly recommended
-  fields        : ['jobTitle'],         // specify fields, id will always be added.
+
+  entities      : {                     // fields for each entity type to index
+    foo         : ['jobTitle']          // if not defined, no fields are indexed
+  },
+
   connection    : { index : indexName } // customize index name
 });
 
@@ -50,9 +54,9 @@ seneca.act({
     cmd: 'save',
     index: 'myIndex',
     type: 'myType',
-    id: 'myId', // either this field
+    id: 'myId', // requires either this id
     data: {
-        _id: 'myId', // or this field
+        _id: 'myId', // or this id
         /*  rest of object here */
     }
 }, callback);

--- a/README.md
+++ b/README.md
@@ -50,8 +50,9 @@ seneca.act({
     cmd: 'save',
     index: 'myIndex',
     type: 'myType',
+    id: 'myId', // either this field
     data: {
-        id: 'myId', // only required field
+        _id: 'myId', // or this field
         /*  rest of object here */
     }
 }, callback);
@@ -62,7 +63,7 @@ seneca.act({
     cmd: 'remove',
     index: 'myIndex',
     type: 'myType',
-    data: { id: 'myId' }
+    id: 'myId'
 }, callback);
 
 
@@ -72,7 +73,7 @@ seneca.act({
     cmd: 'load',
     index: 'myIndex',
     type: 'myType',
-    data: { id: 'myId' }
+    id: 'myId'
 }, callback);
 ```
 

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -100,6 +100,8 @@ function search(options, register) {
   function entityAct(args, cb) {
     assert(args.command, "missing args.command");
 
+    args.command.data.id = args.ent.id;
+
     seneca.act(args.command, function( err ) {
       if(err) { return seneca.fail(err); }
     });
@@ -155,18 +157,22 @@ function search(options, register) {
   * Record management.
   */
   function saveRecord(args, cb) {
-    args.request.id = args.data.id || args.ent.id$;
+    args.request.id = args.data.id;
+
+    if (args.request.id) {
+      args.request.method = 'put';
+    }
 
     esClient.index(args.request, cb);
   }
 
   function loadRecord(args, cb) {
-    args.request.id = args.data.id || args.ent.id$;
+    args.request.id = args.data.id;
     esClient.get(args.request, cb);
   }
 
   function removeRecord(args, cb) {
-    args.request.id = args.data.id || args.ent.id$;
+    args.request.id = args.data.id;
     esClient.delete(args.request, cb);
   }
 

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -17,11 +17,9 @@ function search(options, register) {
   // instead of all-or-nothing.
   var connectionOptions = options.connection || {};
 
-  // Which fields to let through
-  var fieldOptions = options.fields || ['id'];
 
   _.defaults(connectionOptions, {
-    host          : 'localhost:9200',
+    host          : '127.0.0.1:9200',
     sniffInterval : 300000,
     index         : 'seneca',
     sniffOnStart  : true,
@@ -86,7 +84,6 @@ function search(options, register) {
   }
 
   function entityRemove(args, cb) {
-    var prior = this.prior.bind(this);
 
     args.command.cmd = 'remove';
     args.command.data = { id: args.ent.id || args.ent.id$ };
@@ -163,22 +160,18 @@ function search(options, register) {
   * Record management.
   */
   function saveRecord(args, cb) {
-    args.request.id = args.data.id;
-
-    if (args.request.id) {
-      args.request.method = 'put';
-    }
+    args.request.id = args.id || args.data.id;
 
     esClient.index(args.request, cb);
   }
 
   function loadRecord(args, cb) {
-    args.request.id = args.data.id;
+    args.request.id = args.id;
     esClient.get(args.request, cb);
   }
 
   function removeRecord(args, cb) {
-    args.request.id = args.data.id;
+    args.request.id = args.id;
     esClient.delete(args.request, cb);
   }
 

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -89,14 +89,19 @@ function search(options, register) {
   }
 
   function pickFields(args, cb) {
-    var fields = options.fields || false;
-
     var data = args.ent.data$();
 
-    if (fields) {
-      fields.push('_id');
-      data = _.pick.apply(_, [data, fields]);
-    }
+    // allow per-entity field configuration
+    var _type = args.command.type;
+    var _entities = options.entities || {};
+    var _fields = _entities[_type] || [];
+
+    // always pass through _id if it exists
+    // TODO: reconsider this?
+    _fields.push('_id');
+
+
+    data = _.pick.apply(_, [data, _fields]);
 
     args.entityData = data;
     cb(null, args);

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -238,7 +238,7 @@ function search(options, register) {
   // ensures callback is called consistently
   function passArgs(args, cb) {
     return function (err, resp) {
-      if (err) { console.error(err); }
+      if (err) { seneca.fail(err); }
 
       cb(err, args);
     }

--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -222,7 +222,7 @@ function search(options, register) {
   }
 
   function populateRequest(args, cb) {
-    assert.ok(args.data, 'missing args.data');
+    assert.ok(args.data || args.type, 'missing args.data and args.type');
 
     var dataType = args.type || args.data.entity$;
     assert.ok(dataType, 'expected either "type" or "data.entity$" to deduce the entity type');

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "elasticsearch": "^2.1.0",
     "elastic.js": "^1.1.1",
     "underscore": "^1.6.0",
-    "async": "^0.6.2"
+    "async": "^0.6.2",
+    "node-uuid": "^1.4.1"
   },
   "peerDependencies": {
     "seneca": "*"

--- a/test/00entities.js
+++ b/test/00entities.js
@@ -21,6 +21,7 @@ seneca.use('..', {
 before(seneca.ready.bind(seneca));
 describe('entities', function() {
   var foo = seneca.make$('foo');
+  var fooId = 'john doe';
   var esClient = new elasticsearch.Client();
 
   after(function(done) {
@@ -51,7 +52,7 @@ describe('entities', function() {
         cmd: 'load',
         index: indexName,
         type: 'foo',
-        id: foo.id$
+        id: fooId 
       };
       seneca.act(command, loadCb);
     }
@@ -79,7 +80,6 @@ describe('entities', function() {
 function throwOnError(done) {
   return function(err) {
     if (err) { throw err; }
-    console.log(arguments);
     done();
   };
 }

--- a/test/00entities.js
+++ b/test/00entities.js
@@ -46,7 +46,6 @@ describe('entities', function() {
     });
   });
 
-
   it('load', function(done) {
 
     // need to debounce for 50ms to let the data get indexed.

--- a/test/00entities.js
+++ b/test/00entities.js
@@ -15,13 +15,15 @@ seneca.use('mem-store');
 
 seneca.use('..', {
   refreshOnSave: true,
-  fields: ['jobTitle'],
+  entities: {
+    foo: ['jobTitle']
+  },
   connection: { index: indexName }
 });
 
 describe('entities', function() {
+  var fooId; // to hold the generated id
   var foo = seneca.make$('foo');
-  var fooId = 'john doe';
   var esClient = new elasticsearch.Client();
 
   after(function(done) {
@@ -31,14 +33,18 @@ describe('entities', function() {
   });
 
   before(function(done) {
-    foo.id$ = fooId;
     foo.jobTitle = 'important sounding title';
     foo.passHash = 'DO NOT INDEX!';
     seneca.ready(done);
   });
 
   it('should save entity', function(done) {
-    foo.save$(throwOnError(done));
+    foo.save$(function(err, result) {
+      if (err) { return seneca.fail(err); }
+
+      fooId = result.id;
+      done(null);
+    });
   });
 
 

--- a/test/00entities.js
+++ b/test/00entities.js
@@ -10,7 +10,6 @@ var _              = require('underscore');
 var seneca = require('seneca')();
 var indexName = 'seneca-test-entity';
 
-
 seneca.use('mem-store');
 
 seneca.use('..', {
@@ -48,10 +47,10 @@ describe('entities', function() {
   });
 
 
-  it.skip('load', function(done) {
+  it('load', function(done) {
 
-    // need to debounce for 500ms to let the data get indexed.
-    _.delay(delayCb, 500);
+    // need to debounce for 50ms to let the data get indexed.
+    _.delay(delayCb, 50);
 
     function delayCb() {
       var command = {
@@ -65,14 +64,17 @@ describe('entities', function() {
     }
 
     function loadCb(err, resp) {
-      if (err) { throw err; }
-      assert.ok(resp.exists);
+      if (err) { return done(err); }
+
+      assert.ok(resp.found);
       should.exist(resp._source);
+      resp._id.should.eql(fooId);
 
       var src = resp._source;
-      src._id.should.eql('john doe');
       src.jobTitle.should.eql('important sounding title');
       should.not.exist(src.passHash);
+      should.not.exist(src.id);
+      should.not.exist(src.entity$);
 
       done();
     }
@@ -86,7 +88,7 @@ describe('entities', function() {
 
 function throwOnError(done) {
   return function(err) {
-    if (err) { throw err; }
+    if (err) { return done(err); }
     done();
   };
 }

--- a/test/00entities.js
+++ b/test/00entities.js
@@ -11,7 +11,7 @@ var seneca = require('seneca')();
 var indexName = 'seneca-test-entity';
 
 
-seneca.use('mem-store',{ map:{ '-/-/foo':'*' }});
+seneca.use('mem-store');
 
 seneca.use('..', {
   refreshOnSave: true,

--- a/test/00entities.js
+++ b/test/00entities.js
@@ -10,6 +10,7 @@ var _              = require('underscore');
 var seneca = require('seneca')();
 var indexName = 'seneca-test-entity';
 
+
 seneca.use('mem-store',{ map:{ '-/-/foo':'*' }});
 
 seneca.use('..', {
@@ -18,7 +19,6 @@ seneca.use('..', {
   connection: { index: indexName }
 });
 
-before(seneca.ready.bind(seneca));
 describe('entities', function() {
   var foo = seneca.make$('foo');
   var fooId = 'john doe';
@@ -30,10 +30,11 @@ describe('entities', function() {
       .catch(done);
   });
 
-  before(function() {
-    foo.id$ = 'john doe';
+  before(function(done) {
+    foo.id$ = fooId;
     foo.jobTitle = 'important sounding title';
     foo.passHash = 'DO NOT INDEX!';
+    seneca.ready(done);
   });
 
   it('should save entity', function(done) {
@@ -42,7 +43,7 @@ describe('entities', function() {
 
 
   // need to debounce for 500ms to let the data get indexed.
-  it('load', function(done) {
+  it.skip('load', function(done) {
 
     _.delay(delayCb, 500);
 
@@ -73,7 +74,7 @@ describe('entities', function() {
 
 
   it('should remove the entity', function(done) {
-    foo.remove$(foo.id$, throwOnError(done));
+    foo.remove$(fooId, throwOnError(done));
   });
 });
 

--- a/test/00entities.js
+++ b/test/00entities.js
@@ -42,11 +42,15 @@ describe('entities', function() {
 
 
   // need to debounce for 500ms to let the data get indexed.
-  it('load', _.debounce(function(done) {
-    var command = { role: 'search', cmd: 'load', index: indexName, type: 'foo' };
-    command.data = { id$: 'john doe' };
+  it('load', function(done) {
 
-    seneca.act(command, loadCb);
+    _.delay(delayCb, 500);
+
+    function delayCb() {
+      var command = { role: 'search', cmd: 'load', index: indexName, type: 'foo' };
+      command.data = { id$: 'john doe' };
+      seneca.act(command, loadCb);
+    }
 
     function loadCb(err, resp) {
       if (err) { throw err; }
@@ -60,7 +64,7 @@ describe('entities', function() {
 
       done();
     }
-  }, 500));
+  });
 
 
   it('should remove the entity', function(done) {

--- a/test/00entities.js
+++ b/test/00entities.js
@@ -19,8 +19,8 @@ seneca.use('..', {
 });
 
 before(seneca.ready.bind(seneca));
-
 describe('entities', function() {
+  var foo = seneca.make$('foo');
   var esClient = new elasticsearch.Client();
 
   after(function(done) {
@@ -30,14 +30,13 @@ describe('entities', function() {
   });
 
   before(function() {
-    var foo = this.foo = seneca.make$('foo');
     foo.id$ = 'john doe';
     foo.jobTitle = 'important sounding title';
     foo.passHash = 'DO NOT INDEX!';
   });
 
   it('should save entity', function(done) {
-    this.foo.save$(throwOnError(done));
+    foo.save$(throwOnError(done));
   });
 
 
@@ -47,8 +46,13 @@ describe('entities', function() {
     _.delay(delayCb, 500);
 
     function delayCb() {
-      var command = { role: 'search', cmd: 'load', index: indexName, type: 'foo' };
-      command.data = { id$: 'john doe' };
+      var command = {
+        role: 'search',
+        cmd: 'load',
+        index: indexName,
+        type: 'foo',
+        id: foo.id$
+      };
       seneca.act(command, loadCb);
     }
 
@@ -68,13 +72,14 @@ describe('entities', function() {
 
 
   it('should remove the entity', function(done) {
-    this.foo.remove$(this.foo.id$, throwOnError(done));
+    foo.remove$(foo.id$, throwOnError(done));
   });
 });
 
 function throwOnError(done) {
   return function(err) {
     if (err) { throw err; }
+    console.log(arguments);
     done();
   };
 }

--- a/test/00entities.js
+++ b/test/00entities.js
@@ -42,9 +42,9 @@ describe('entities', function() {
   });
 
 
-  // need to debounce for 500ms to let the data get indexed.
   it.skip('load', function(done) {
 
+    // need to debounce for 500ms to let the data get indexed.
     _.delay(delayCb, 500);
 
     function delayCb() {

--- a/test/elasticsearch.test.js
+++ b/test/elasticsearch.test.js
@@ -46,15 +46,25 @@ describe('records', function() {
   });
 
   it('save', function(done) {
-    var command = { role: 'search', cmd: 'save', index: indexName, type: 'type1' };
+    var command = {
+      role: 'search',
+      cmd: 'save',
+      index: indexName,
+      type: 'type1'
+    };
     command.data = { id: 'abcd', name: 'caramel' };
       
     seneca.act(command, throwOnError(done));
   });
 
   it('load', function(done) {
-    var command = { role: 'search', cmd: 'load', index: indexName, type: 'type1' };
-    command.data = { id: 'abcd' };
+    var command = {
+      role: 'search',
+      cmd: 'load',
+      index: indexName,
+      type: 'type1',
+      id: 'abcd'
+    };
 
     seneca.act(command, loadCb);
 
@@ -72,7 +82,12 @@ describe('records', function() {
   });
 
   it('search', function(done) {
-    var command = { role: 'search', cmd: 'search', index: indexName, type: 'type1' };
+    var command = {
+      role: 'search',
+      cmd: 'search',
+      index: indexName,
+      type: 'type1'
+    };
     command.data = { id: 'abcd' };
 
     seneca.act(command, searchCb);
@@ -92,8 +107,13 @@ describe('records', function() {
   });
 
   it('remove', function(done) {
-    var command = { role: 'search', cmd: 'remove', index: indexName, type: 'type1' };
-    command.data = { id: 'abcd' };
+    var command = {
+      role: 'search',
+      cmd: 'remove',
+      index: indexName,
+      type: 'type1',
+      id: 'abcd'
+    };
     seneca.act(command, removeCb);
 
     function removeCb(err, resp) {

--- a/test/elasticsearch.test.js
+++ b/test/elasticsearch.test.js
@@ -52,7 +52,7 @@ describe('records', function() {
       index: indexName,
       type: 'type1'
     };
-    command.data = { id: 'abcd', name: 'caramel' };
+    command.data = { _id: 'abcd', name: 'caramel' };
       
     seneca.act(command, throwOnError(done));
   });
@@ -72,9 +72,12 @@ describe('records', function() {
       if (err) { throw err; }
       assert.ok(resp.found);
       should.exist(resp._source);
+      should.exist(resp._id);
+
+      resp._id.should.eql('abcd');
 
       var src = resp._source;
-      src.id.should.eql('abcd');
+      src._id.should.eql('abcd');
       src.name.should.eql('caramel');
 
       done();
@@ -99,7 +102,8 @@ describe('records', function() {
 
       var result = resp.hits.hits[0]
       should.exist(result._source);
-      result._source.id.should.eql('abcd');
+      result._id.should.eql('abcd');
+      result._source._id.should.eql('abcd');
       result._source.name.should.eql('caramel');
 
       done();


### PR DESCRIPTION
This PR should defer to any id$ already set, then try to use the ES-style _id field, then try to generate a uuid. 
Fixes #2.

It also has per-entity type indexing configuration (ala #7) , but it doesn't short circuit the whole process. Unconfigured entity types will still get indexed, but none of their fields will.
