### PR TITLE
When saving an entity, allow $id to be set to ent.id

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -108,7 +108,7 @@ function search(options, register) {
   }
 
   function entitySave(args, cb) {
-    args.ent.id$ = args.ent.id$ || args.ent._id || uuid.v4();
+    args.ent.id$ = args.ent.id$ || args.ent._id || args.ent.id || uuid.v4();
 
     args.command.cmd = 'save';
     args.command.data = args.entityData;


### PR DESCRIPTION
See #11
This allows `$id` to be set to `ent.id` if `ent.$id` and `ent._id` are undefined.
