### PR TITLE
remove sniffOnStart to stop errors on startup.

### DIFF
--- a/elasticsearch.js
+++ b/elasticsearch.js
@@ -25,7 +25,6 @@ function search(options) {
     host          : '127.0.0.1:9200',
     sniffInterval : 300000,
     index         : 'seneca',
-    sniffOnStart  : true,
     log           : 'error'
   });
 


### PR DESCRIPTION
All our applications that make use of this module kept on throwing a worrying error message on start, and I finally nailed it down to this setting.

removing this makes it go away, and I can't see any other regressions.

```
Elasticsearch ERROR: 2015-05-31T04:11:07Z
  Error: Request error, retrying -- socket hang up
      at Log.error (/Users/adrian/Projects/nearform[snip]/node_modules/seneca-elasticsearch/node_modules/elasticsearch/src/lib/log.js:213:60)
      at checkRespForFailure (/Users/adrian/Projects/nearform/[snip]/node_modules/seneca-elasticsearch/node_modules/elasticsearch/src/lib/transport.js:185:18)
      at HttpConnector.<anonymous> (/Users/adrian/Projects/nearform/[snip]/node_modules/seneca-elasticsearch/node_modules/elasticsearch/src/lib/connectors/http.js:150:7)
      at ClientRequest.bound (/Users/adrian/Projects/nearform/[snip]/node_modules/seneca-elasticsearch/node_modules/elasticsearch/node_modules/lodash-node/modern/internals/baseBind.js:56:17)
      at ClientRequest.emit (events.js:95:17)
      at Socket.socketCloseListener (http.js:1526:9)
      at Socket.emit (events.js:117:20)
      at TCP.close (net.js:465:12)
```
